### PR TITLE
return False for Boolean comparisons with nonExistantElement objects

### DIFF
--- a/holmium/core/pageobject.py
+++ b/holmium/core/pageobject.py
@@ -430,6 +430,9 @@ class NonexistentElement(object):
                                                                                         self.webdriver_exception,
                                                                                         self.locator_type, self.query_string)
 
+    def __nonzero__(self):
+        return False
+
     def __repr__(self):
         return "holmium.core.pageobject."+str(self)
 


### PR DESCRIPTION
Return False for boolean comparisons with nonExistantElement objects
